### PR TITLE
feat: supports prometheus-native metrics via alloy scrape/forward configs 

### DIFF
--- a/config/alloy.alloy
+++ b/config/alloy.alloy
@@ -50,6 +50,19 @@ otelcol.exporter.loki "default" {
     forward_to = [loki.write.default.receiver]
 }
 
+// -------------------------------------------------------| service discovery
+discovery.docker "containers" {
+    host = "unix:///var/run/docker.sock"
+    refresh_interval = "15s"
+}
+
+// -------------------------------------------------------| prometheus scraping
+prometheus.scrape "local_svc__api_gateway" {
+    metrics_path = "/metrics"
+    targets = discovery.docker.containers.targets
+    forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
 // -------------------------------------------------------| sinks
 // metrics
 prometheus.remote_write "mimir" {

--- a/config/alloy.alloy
+++ b/config/alloy.alloy
@@ -43,12 +43,14 @@ pyroscope.receive_http "default" {
 }
 
 // -------------------------------------------------------| prometheus scrapers
+// auto-discovered endpoints from discovery.docker
 prometheus.scrape "docker_metrics" {
     metrics_path = "/metrics"
     targets = discovery.docker.containers.targets
     forward_to = [prometheus.remote_write.mimir.receiver]
 }
 
+// manual entry
 prometheus.scrape "local_svc__api_gateway" {
     metrics_path = "/metrics"
     targets = [

--- a/config/alloy.alloy
+++ b/config/alloy.alloy
@@ -7,7 +7,16 @@ logging {
   format = "logfmt"
 }
 
+// -------------------------------------------------------| service discovery
+// discover containers managed by the local docker daemon.
+// provides targets to other pipeline components.
+discovery.docker "containers" {
+    host = "unix:///var/run/docker.sock"
+    refresh_interval = "15s"
+}
+
 // -------------------------------------------------------| otlp ingest
+// primary receiver for otlp/otel-native telemetry
 otelcol.receiver.otlp "default" {
     grpc {
         endpoint = "0.0.0.0:4317"
@@ -24,6 +33,7 @@ otelcol.receiver.otlp "default" {
 }
 
 // -------------------------------------------------------| pyroscope ingest
+// receiver for pyroscope runtime perf sampling
 pyroscope.receive_http "default" {
    http {
        listen_address = "0.0.0.0"
@@ -32,6 +42,12 @@ pyroscope.receive_http "default" {
    forward_to = [pyroscope.write.backend.receiver]
 }
 
+// -------------------------------------------------------| prometheus scrapers
+prometheus.scrape "docker_metrics" {
+    metrics_path = "/metrics"
+    targets = discovery.docker.containers.targets
+    forward_to = [prometheus.remote_write.mimir.receiver]
+}
 
 // -------------------------------------------------------| batch processor
 otelcol.processor.batch "default" {
@@ -48,19 +64,6 @@ otelcol.exporter.prometheus "default" {
 }
 otelcol.exporter.loki "default" {
     forward_to = [loki.write.default.receiver]
-}
-
-// -------------------------------------------------------| service discovery
-discovery.docker "containers" {
-    host = "unix:///var/run/docker.sock"
-    refresh_interval = "15s"
-}
-
-// -------------------------------------------------------| prometheus scraping
-prometheus.scrape "local_svc__api_gateway" {
-    metrics_path = "/metrics"
-    targets = discovery.docker.containers.targets
-    forward_to = [prometheus.remote_write.mimir.receiver]
 }
 
 // -------------------------------------------------------| sinks

--- a/config/alloy.alloy
+++ b/config/alloy.alloy
@@ -32,6 +32,19 @@ pyroscope.receive_http "default" {
    forward_to = [pyroscope.write.backend.receiver]
 }
 
+// -------------------------------------------------------| prometheus scraping
+prometheus.scrape "local_svc__api_gateway" {
+    metrics_path = "/metrics"
+    targets = [
+        {
+            __address__ = "host.docker.internal:9090",
+            job = "local_api_gateway",
+        },
+    ]
+
+    forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
 
 // -------------------------------------------------------| batch processor
 otelcol.processor.batch "default" {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,8 @@ services:
       - "4040:4040"     # pyroscope http
     volumes:
       - ./config/alloy.alloy:/etc/alloy/local.alloy
+      # privileged: mount docker socket to support discovery.docker in ally 
+      - /var/run/docker.sock:/var/run/docker.sock
 
   # loki is loki. it holds logs
   loki:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - "4040:4040"     # pyroscope http
     volumes:
       - ./config/alloy.alloy:/etc/alloy/local.alloy
-      # privileged: mount docker socket to support discovery.docker in ally 
+      # privileged: mount docker.sock to support discovery.docker in alloy
       - /var/run/docker.sock:/var/run/docker.sock
 
   # loki is loki. it holds logs

--- a/readme.md
+++ b/readme.md
@@ -59,3 +59,29 @@ that's by design: we capture twice because you're logging twice.
 in this case, you probably want to prefer the otel logs. otel/tempo will add precise labels to the ingested jobs
 depending on your otel resource configs.   
 also worth noting that the docker.sock logs can be directly excluded with `{job!="docker_sock"}`
+
+### prometheus metrics 
+
+this was created with a preference for otel-native telemetry.   
+it has support for prometheus-native metrics scraping, but this is manual:   
+in `config/alloy.alloy`, find/add prometheus.scrape block(s) for the service(s) you want to scrape metrics from.
+
+using this scrape as an example: 
+```text
+prometheus.scrape "local_svc__api_gateway" {                        // [1] unique name for the config  
+    metrics_path = "/metrics"                                       // [2] path on the service to scrape metrics from 
+    targets = [
+        {
+            __address__ = "host.docker.internal:9090",              // [3] http address for service. note host.docker.internal for docker on mac 
+            job = "local_api_gateway",                              // [4] job name, attached to scraped metrics. 
+        },
+    ]
+
+    forward_to = [prometheus.remote_write.mimir.receiver]           // [5] scraped metrics are forwarded to the mimir receiver defined in alloy
+}
+```
+
+with that: 
+- (2,3) alloy will scrape metrics from a service running at host.docker.internal:9090/metrics (localhost:9090/metrics outside of the docker context)  
+- (3,4) found metrics will be labeled with {instance="host.docker.internal:9090", job="local_api_gateway"} 
+- (5) found metrics will be forwarded to the mimir instance deployed from this compose stack


### PR DESCRIPTION
adds support for prom-native metrics (vs existing otel-native metrics).  

this uses alloy configs for: 
a) discovery.docker to expose targets managed by the docker daemon (requires privileged alloy container, mounting docker.sock)   
b) manual scrape configs, with readme docs and example/bootstrap config  in `config/alloy.alloy` 